### PR TITLE
Model initialization

### DIFF
--- a/python_backend/src/backend/ai_backend_manager.py
+++ b/python_backend/src/backend/ai_backend_manager.py
@@ -67,7 +67,9 @@ class AIBackendManager:
                 available_models = self.list_models()
                 if available_models:
                     self.current_model = available_models[0]
-                    self.backend_settings[self.current_backend]["default_model"] = available_models[0]
+                    self.backend_settings[self.current_backend]["default_model"] = (
+                        available_models[0]
+                    )
                     logger.info(f"Set default model to {self.current_model}")
                 else:
                     logger.warning(f"No models available for {self.current_backend}")
@@ -77,7 +79,9 @@ class AIBackendManager:
                 logger.error(f"Error fetching {self.current_backend} models: {e}")
         else:
             # Settings define default for non-local backends
-            self.current_model = self.backend_settings[self.current_backend]["default_model"]
+            self.current_model = self.backend_settings[self.current_backend][
+                "default_model"
+            ]
             logger.info(f"Set default model to {self.current_model}")
 
     def set_backend(self, backend_type: str) -> bool:


### PR DESCRIPTION
Separated out function to initialize default model based on user downloaded models for local backends.

Made `self.list_models()` sync since it uses `requests` which is blocking. This allows us to call the function in`AIBackendManager.init()`.

Potential issue to keep in mind: with no locally downloaded models, Title bar says "Model: Unknown"

Fixes #5.